### PR TITLE
feat:  Not count length some link nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add "sentence-length" to your `.textlintrc`.
 - `max`
     - default: 100
     - The total number of characters allowed on each sentences.
-    - => Sentence.length > 100 and throw Error
+    - Sentence.length > 100 and throw Error
 
 ```
 {
@@ -35,6 +35,35 @@ Add "sentence-length" to your `.textlintrc`.
     }
 }
 ```
+
+## Exception
+
+- Except BlockQuote
+- Except a single link node
+
+
+**OK**:
+
+```
+> LONG LONG LONG LONG LONG LONG LONG LONG Quote text
+
+a single link node ↓
+
+[textlint/textlint-filter-rule-comments: textlint filter rule that disables all rules between comments directive.](https://github.com/textlint/textlint-filter-rule-comments)
+
+a single link node ↓
+
+- [textlint/textlint-filter-rule-comments: textlint filter rule that disables all rules between comments directive.](https://github.com/textlint/textlint-filter-rule-comments)
+```
+
+**NG**:
+
+This sentence includes one link and two Str.
+
+```
+This is [textlint/textlint-filter-rule-comments: textlint filter rule that disables all rules between comments directive.](https://github.com/textlint/textlint-filter-rule-comments).
+```
+
 
 ## Related Rules
 

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
   "dependencies": {
     "mdast-util-to-string": "^1.0.0",
     "sentence-splitter": "^2.0.0",
-    "textlint-rule-helper": "^1.1.4"
+    "textlint-rule-helper": "^2.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.1.18",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.1.18",
     "espower-babel": "^4.0.0",
-    "mocha": "^2.3.3",
+    "mocha": "^3.2.0",
     "power-assert": "^1.2.0",
-    "textlint-tester": "^1.2.0"
+    "textlint-tester": "^2.1.0"
   }
 }

--- a/src/sentence-length.js
+++ b/src/sentence-length.js
@@ -19,7 +19,7 @@ export default function(context, options = {}) {
             if (helper.isChildNode(node, [Syntax.BlockQuote])) {
                 return;
             }
-            // If a single Link node in the paragraph node, should be ignore the link length.
+            // If a single Link node in the paragraph node, should be ignore the link length
             const isChildrenSingleLinkNode = node.children.length === 1 && node.children[0].type === Syntax.Link;
             if (isChildrenSingleLinkNode) {
                 return;
@@ -34,9 +34,9 @@ export default function(context, options = {}) {
                 let sentenceText = sentence.value;
                 // larger than > 100
                 if (sentenceText.length > maxLength) {
-                    let currentLine = node.loc.start.line;
+                    const currentLine = node.loc.start.line;
                     const addedLine = isStartWithNewLine(sentenceText)
-                        ? sentence.loc.start.line + 1  // \n string
+                        ? sentence.loc.start.line // \n string
                         : sentence.loc.start.line - 1; // string
                     let paddingLine = Math.max(addedLine, 0);
                     let paddingIndex = sentence.range[0];

--- a/src/sentence-length.js
+++ b/src/sentence-length.js
@@ -9,29 +9,34 @@ const isStartWithNewLine = (text) => {
 const defaultOptions = {
     max: 100
 };
-export default function (context, options = {}) {
+export default function(context, options = {}) {
     const maxLength = options.max || defaultOptions.max;
     const helper = new RuleHelper(context);
-    let {Syntax, RuleError, report} = context;
+    const {Syntax, RuleError, report} = context;
     // toPlainText
     return {
         [Syntax.Paragraph](node){
             if (helper.isChildNode(node, [Syntax.BlockQuote])) {
                 return;
             }
-            let text = toString(node);
+            // If a single Link node in the paragraph node, should be ignore the link length.
+            const isChildrenSingleLinkNode = node.children.length === 1 && node.children[0].type === Syntax.Link;
+            if (isChildrenSingleLinkNode) {
+                return;
+            }
+            const text = toString(node);
             // empty break line == split sentence
-            let sentences = split(text, {
+            const sentences = split(text, {
                 newLineCharacters: "\n\n"
             });
             sentences.forEach(sentence => {
                 // TODO: should trim()?
                 let sentenceText = sentence.value;
-                // bigger than
+                // larger than > 100
                 if (sentenceText.length > maxLength) {
                     let currentLine = node.loc.start.line;
                     const addedLine = isStartWithNewLine(sentenceText)
-                        ? sentence.loc.start.line + 1// \n string
+                        ? sentence.loc.start.line + 1  // \n string
                         : sentence.loc.start.line - 1; // string
                     let paddingLine = Math.max(addedLine, 0);
                     let paddingIndex = sentence.range[0];

--- a/test/sentence-length-test.js
+++ b/test/sentence-length-test.js
@@ -9,6 +9,7 @@ tester.run("textlint-rule-sentence-length", rule, {
         "Test`code`です。",
         // Exception: A link in the Paragraph
         "[textlint/textlint-filter-rule-comments: textlint filter rule that disables all rules between comments directive.](https://github.com/textlint/textlint-filter-rule-comments)",
+        "- [textlint/textlint-filter-rule-comments: textlint filter rule that disables all rules between comments directive.](https://github.com/textlint/textlint-filter-rule-comments)",
         {
             text: "> ignore",
             options: {

--- a/test/sentence-length-test.js
+++ b/test/sentence-length-test.js
@@ -2,11 +2,13 @@
 "use strict";
 import rule from "../src/sentence-length";
 import TextLintTester from "textlint-tester";
-var tester = new TextLintTester();
+const tester = new TextLintTester();
 tester.run("textlint-rule-sentence-length", rule, {
     valid: [
         "This is a article",
         "Test`code`です。",
+        // Exception: A link in the Paragraph
+        "[textlint/textlint-filter-rule-comments: textlint filter rule that disables all rules between comments directive.](https://github.com/textlint/textlint-filter-rule-comments)",
         {
             text: "> ignore",
             options: {


### PR DESCRIPTION
If a single Link node in the paragraph node, should be ignore the link length.

**OK**:

```
[textlint/textlint-filter-rule-comments: textlint filter rule that disables all rules between comments directive.](https://github.com/textlint/textlint-filter-rule-comments)

- [textlint/textlint-filter-rule-comments: textlint filter rule that disables all rules between comments directive.](https://github.com/textlint/textlint-filter-rule-comments)
```

**NG**:

This sentence includes one link and two Str.

```
This is [textlint/textlint-filter-rule-comments: textlint filter rule that disables all rules between comments directive.](https://github.com/textlint/textlint-filter-rule-comments).
```
